### PR TITLE
Fixed issue with response not sending a status code if error is HttpQueryError

### DIFF
--- a/src/ApolloServer/index.js
+++ b/src/ApolloServer/index.js
@@ -35,7 +35,7 @@ class ApolloServer {
                 })
             }
 
-            response.status(error.status)
+            response.status(error.statusCode)
                     .send(error.message)
         })
     }


### PR DESCRIPTION
#5 If no response code is returned to Chrome, the response body is not parsed, making it impossible to debug the error…

I used way to long figuring it was an error handling error… xD

